### PR TITLE
Fjerner ubrukte ingresser og legger til dev.nav.no

### DIFF
--- a/nais/dev/q0.json
+++ b/nais/dev/q0.json
@@ -2,6 +2,8 @@
   "namespace": "q0",
   "ingresses": [
     "https://sosialhjelp-fagsystem-mock-q0.dev-sbs.nais.io/sosialhjelp/fagsystem-mock",
+    "https://www-q0.dev.nav.no/sosialhjelp/woldena",
+    "https://www-q0.dev.nav.no/sosialhjelp/fagsystem-mock",
     "https://www-q0.nav.no/sosialhjelp/fagsystem-mock"
   ],
   "appresCmsUrl": "https://appres-q0.nav.no",

--- a/nais/dev/q1.json
+++ b/nais/dev/q1.json
@@ -2,6 +2,8 @@
   "namespace": "q1",
   "ingresses": [
     "https://sosialhjelp-fagsystem-mock-q1.dev-sbs.nais.io/sosialhjelp/fagsystem-mock",
+    "https://www-q1.dev.nav.no/sosialhjelp/woldena",
+    "https://www-q1.dev.nav.no/sosialhjelp/fagsystem-mock",
     "https://www-q1.nav.no/sosialhjelp/fagsystem-mock"
   ],
   "appresCmsUrl": "https://appres-q1.nav.no",


### PR DESCRIPTION
Fordi vi flytter de andre appene over her så de er tilgjenglig fra naisdevice. Dette pga: 
loginservice er kun tilgjengelig fra naisdevice på dev.nav.no, og for å ta i bruk denne må appene våre kjøre på samme ingress.